### PR TITLE
Recover wrapper task in build.gradle

### DIFF
--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -28,4 +28,7 @@ dependencies {
 // end::dependencies[]
 
 // tag::wrapper[]
+task wrapper(type: Wrapper) {
+    gradleVersion = '2.13'
+}
 // end::wrapper[]


### PR DESCRIPTION
Gradle wrapper task is failed because of missing wrapper task in build.gradle. So I added these statements.